### PR TITLE
让错误处理程序兼容被 throw 的字符串

### DIFF
--- a/app.js
+++ b/app.js
@@ -59,7 +59,7 @@ if (app.get('env') === 'development') {
   app.use(function(err, req, res, next) { // jshint ignore:line
     res.status(err.status || 500);
     res.render('error', {
-      message: err.message,
+      message: err.message || err,
       error: err
     });
   });
@@ -69,7 +69,7 @@ if (app.get('env') === 'development') {
 app.use(function(err, req, res, next) { // jshint ignore:line
   res.status(err.status || 500);
   res.render('error', {
-    message: err.message,
+    message: err.message || err,
     error: {}
   });
 });


### PR DESCRIPTION
javascript-sdk 里有很多地方直接 throw 字符串（而不是 Error 对象），目前不会显示任何提示，令人很抓狂 ...
