### PR TITLE
bugfix: 如果当前环境已经有 domain 则未处理异常捕获中间件不会重复创建 domain

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,7 +23,12 @@ app.use(cookieParser());
 
 // 未处理异常捕获 middleware
 app.use(function(req, res, next) {
-  var d = domain.create();
+  var d = null;
+  if (process.domain) {
+    d = process.domain;
+  } else {
+    d = domain.create();
+  }
   d.add(req);
   d.add(res);
   d.on('error', function(err) {


### PR DESCRIPTION
主要是为了解决 AV.Cloud.CookieSession
写在未处理异常捕获中间件前面时，因为该中间件会重新创建 domain，会使
cookieSesion 无法找到正确的 domain 而导致状态不正确。
