### PR TITLE
remove '.avoscloud/' , since it will be added by 'avoscloud-code-command'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ start.sh
 # VIM
 *~
 *.swp
-.avoscloud/


### PR DESCRIPTION
'.avoscloud/' 这条gitignore会在avoscloud 命令行工具创建项目的时候自动被添加。与本项目无太大关系，而且会导致 avoscloud new 出来的Node项目的.gitignore文件重复添加此字段，建议删除。

// avoscloud-code-command/bin/run.js， line 743
function createConfigIfNessary() {
    var configDir = path.join(CLOUD_PATH, ".avoscloud");
    if (fs.existsSync(configDir))
        return;
    fs.mkdirSync(configDir);
    //append it to .gitignore
    fs.appendFileSync(path.join(CLOUD_PATH, ".gitignore"), ".avoscloud/\n");
}
