### PR TITLE
仅当没有路由发送响应时才抛出 404 异常

### DIFF
--- a/app.js
+++ b/app.js
@@ -49,12 +49,13 @@ app.get('/', function(req, res) {
 // 可以将一类的路由单独保存在一个文件中
 app.use('/todos', todos);
 
-// 如果任何路由都没匹配到，则认为 404
-// 生成一个异常让后面的 err handler 捕获
 app.use(function(req, res, next) {
-  var err = new Error('Not Found');
-  err.status = 404;
-  next(err);
+  // 如果任何一个路由都没有返回响应，则抛出一个 404 异常给后续的异常处理器
+  if (!res.headersSent) {
+    var err = new Error('Not Found');
+    err.status = 404;
+    next(err);
+  }
 });
 
 // error handlers


### PR DESCRIPTION
在发回响应（`res.send`）之后继续调用 next 进行后续处理也是 express 的常见用法，所以应该只在没有路由发回响应（`!res.headersSent`）的情况下抛出 404 异常，否则就会出现 `Error: Can't set headers after they are sent`.
