### PR TITLE
feat: engines.node 10.x -> 12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "nodemon": "^1.18.7"
   },
   "engines": {
-    "node": "10.x"
+    "node": "12.x"
   }
 }


### PR DESCRIPTION
12.x is the current LTS version of node.js